### PR TITLE
[CodeThreat] Update com.thoughtworks.xstream:xstream from 1.4.16 to 1.4.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.16</version>
+        <version>1.4.17</version>
       </dependency>
       <dependency>
         <groupId>cglib</groupId>


### PR DESCRIPTION
This PR was generated by CodeThreat utilizing authenticated user credentials.

  ## Issue Description

  ### XStream is software for serializing Java objects to XML and back again. A vulnerability in XStream versions prior to 1.4.17 may allow a remote attacker has sufficient rights to execute commands of the host only by manipulating the processed input stream. No user who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types is affected. The vulnerability is patched in version 1.4.17.
  
  ### Changes included in this PR
  
  - Modifications to the following files to address the vulnerabilities with updated dependencies:
    - pom.xml
  
  ### Security Issues Addressed
  
  #### Through Dependency Upgrades:
  
  | Issue | Upgrade | Severity |
  | --- | --- | --- |
  | XStream: remote command execution attack by manipulating the processed input stream | com.thoughtworks.xstream:xstream: 1.4.16 -> 1.4.17 | HIGH |
  
  Review the modifications in this PR to confirm they do not introduce any issues to your project.
  