### PR TITLE
[CodeThreat] Update com.thoughtworks.xstream:xstream from 1.4.16 to 1.4.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.16</version>
+        <version>1.4.18</version>
       </dependency>
       <dependency>
         <groupId>cglib</groupId>


### PR DESCRIPTION
This PR was generated by CodeThreat utilizing authenticated user credentials.

  ## Issue Description

  ### XStream is a simple library to serialize objects to XML and back again. In affected versions this vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. A user is only affected if using the version out of the box with JDK 1.7u21 or below. However, this scenario can be adjusted easily to an external Xalan that works regardless of the version of the Java runtime. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types. XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.
  
  ### Changes included in this PR
  
  - Modifications to the following files to address the vulnerabilities with updated dependencies:
    - pom.xml
  
  ### Security Issues Addressed
  
  #### Through Dependency Upgrades:
  
  | Issue | Upgrade | Severity |
  | --- | --- | --- |
  | xstream: Arbitrary code execution via unsafe deserialization of Xalan xsltc.trax.TemplatesImpl | com.thoughtworks.xstream:xstream: 1.4.16 -> 1.4.18 | HIGH |
  
  Review the modifications in this PR to confirm they do not introduce any issues to your project.
  